### PR TITLE
auto assign reviewers in PRs

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,23 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: true
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers: 
+  - mfenner
+  - kjgarza
+  - richardhallett
+  - sarala
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it 
+skipKeywords:
+  - wip
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 1
+
+# Set to author to set pr creater as assignee
+addAssignees: author


### PR DESCRIPTION
randomly assign reviewers automatically so we don't assign always the same person as a reviewer.

## Technical proposal

Add auto-assign configuration with GithubBot.
this is a test for Sashimi.

https://github.com/apps/auto-assign

