### PR TITLE
fix codeclimate analysis error

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -32,3 +32,7 @@ exclude_paths:
 - db/
 - spec/
 - vendor/
+plugins:
+  rubocop:
+  enabled: true
+  channel: rubocop-0-73


### PR DESCRIPTION
It appears that some of the older Rubocop channels don't support the `rubocop-rails` gem, but rubocop-0-73 (and some of our other, newer channels) does, as seen here.