### PR TITLE
Feature transfer usage reports to a different provider

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -112,7 +112,6 @@ class ReportsController < ApplicationController
   end
 
   def transfer
-    puts params
     fail JSON::ParserError, "Report Transfer need to include a target_id member or consortium"  if params[:target_id].blank?
 
     reports = Report.where(client_id: params[:client_id])

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -111,6 +111,21 @@ class ReportsController < ApplicationController
     end
   end
 
+  def transfer
+    puts params
+    fail JSON::ParserError, "Report Transfer need to include a target_id member or consortium"  if params[:target_id].blank?
+
+    reports = Report.where(client_id: params[:client_id])
+    fail ActiveRecord::RecordNotFound if reports.blank?
+
+    if Report.transfer(params)
+      render json: @report, status: :ok
+    else
+      Rails.logger.warn @report.errors.inspect
+      render json: serialize(@report.errors), status: :unprocessable_entity
+    end
+  end
+
   protected
 
   def set_report

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -116,6 +116,18 @@ class Report < ApplicationRecord
     end
   end
 
+  def self.transfer(options = {})
+    reports = Report.where(client_id: options[:client_id])
+    raise ActiveRecord::RecordNotFound if reports.blank?
+
+    Rails.logger.info "[TransferReports] Transfering #{reports.length} reports from #{options[:client_id]} to #{options[:target_id]}" 
+
+    reports.each do |report|
+      puts report.inspect
+      report.update_attribute(:provider_id, options[:target_id])
+    end
+  end
+
   private
 
   # random number that fits into MySQL bigint field (8 bytes)

--- a/config/initializers/json_param_key_transform.rb
+++ b/config/initializers/json_param_key_transform.rb
@@ -10,7 +10,9 @@ ActionDispatch::Request.parameter_parsers[:json] = -> (raw_post) {
   # data.deep_transform_keys! { |key| key.underscore }
 
   data.transform_keys! { |key| key.underscore }
-  header = data.fetch("report_header").deep_transform_keys { |key| key.underscore }
-  data["report_header"] = header
+  unless data.fetch("report_header", nil) == nil
+    header = data.fetch("report_header").deep_transform_keys { |key| key.underscore }
+    data["report_header"] = header
+  end
   data
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   add_swagger_route 'POST', '//reports', controller_name: 'reports', action_name: 'create'
 
   get 'repositories-usage-reports/:id', :to => 'publishers#show', constraints: { :id => /.+/ }
+  post 'reports/transfer', :to => 'reports#transfer', constraints: { :id => /.+/ }
 
 
   resources :publishers, constraints: { :id => /.+/ }, format: false, defaults: { format: false }

--- a/lib/middleware/compressed_requests.rb
+++ b/lib/middleware/compressed_requests.rb
@@ -4,26 +4,29 @@ class CompressedRequests
   end
 
   def method_handled?(env)
-    !!(env['REQUEST_METHOD'] =~ /(POST|PUT)/)
+    !!(env["REQUEST_METHOD"] =~ /(POST|PUT)/)
   end
 
   def encoding_handled?(env)
-    ['gzip', 'deflate'].include? env['HTTP_CONTENT_ENCODING']
+    ["gzip", "deflate"].include? env["HTTP_CONTENT_ENCODING"]
   end
 
   def call(env)
     request = Rack::Request.new(env)
+
     if method_handled?(env) && encoding_handled?(env)
-      extracted = decode(env['rack.input'], env['HTTP_CONTENT_ENCODING'])
+      extracted = decode(env["rack.input"], env["HTTP_CONTENT_ENCODING"])
       hsh = JSON.parse(extracted)
 
-      request.update_param('report_header', hsh.fetch("report-header", {}).deep_transform_keys { |key| key.tr('-', '_') })
-      request.update_param('compressed', env['rack.input'])
-      request.update_param('encoding', env['HTTP_CONTENT_ENCODING'])
+      unless hsh.fetch("report-header", nil) == nil
+        request.update_param("report_header", hsh.fetch("report-header", {}).deep_transform_keys { |key| key.tr("-", "_") })
+        request.update_param("compressed", env["rack.input"])
+        request.update_param("encoding", env["HTTP_CONTENT_ENCODING"])
+      end
 
-      env.delete('HTTP_CONTENT_ENCODING')
-      env['CONTENT_LENGTH'] = extracted.length
-      env['rack.input'] = StringIO.new(extracted)
+      env.delete("HTTP_CONTENT_ENCODING")
+      env["CONTENT_LENGTH"] = extracted.length
+      env["rack.input"] = StringIO.new(extracted)
     end
 
     status, headers, response = @app.call(env)
@@ -33,8 +36,8 @@ class CompressedRequests
   def decode(input, content_encoding)
     case content_encoding
     # https://tickets.puppetlabs.com/browse/PUP-7251
-    when 'gzip' then Zlib::GzipReader.new(input, encoding: Encoding::BINARY).read
-    when 'deflate' then Zlib::Inflate.inflate(input.read)
+    when "gzip" then Zlib::GzipReader.new(input, encoding: Encoding::BINARY).read
+    when "deflate" then Zlib::Inflate.inflate(input.read)
     end
   end
 end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe Report, type: :model do
   let(:subject)  { create(:report) }
@@ -7,7 +7,24 @@ describe Report, type: :model do
     it { should validate_presence_of(:report_id) }
     it { should validate_presence_of(:created_by) }
     it { should validate_presence_of(:created) }
-    # it { should validate_presence_of(:report_datasets) }
     it { should validate_presence_of(:reporting_period) }
+  end
+
+  describe "transfer" do
+    let(:options) { { client_id: subject.client_id, target_id: "BL" } }
+    let(:bad_options) { { client_id: "fake.fake", target_id: "BL" } }
+
+    it "works" do
+      expect(Report.where(provider_id: "BL").length).to eq(0)
+
+      transfer = Report.transfer(options)
+      expect(transfer).to be_truthy
+
+      expect(Report.where(provider_id: "BL").length).to eq(1)
+    end
+
+    it "not existent client_id" do
+      expect{ Report.transfer(bad_options) }.to raise_exception(ActiveRecord::RecordNotFound)
+    end
   end
 end

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -253,13 +253,11 @@ describe "Reports", type: :request do
 
   describe "POST /reports/transfer" do
     let!(:reports_transfer) { create_list(:report, 3, compressed: nil) }
-    let(:transfer_headers) { { "ACCEPT" => "json", "CONTENT_TYPE" => "json", "Authorization" => "Bearer " + bearer } }
-
 
     context "when the request is valid" do
       let(:params) {  { "client-id" => reports_transfer.first.client_id, "target-id" => "BL" } }
 
-      before { post "/reports/transfer", params: params.to_json, headers: transfer_headers }
+      before { post "/reports/transfer", params: params.to_json, headers: headers }
 
       it "transfer all reports from a client" do
         expect(response).to have_http_status(200)
@@ -269,7 +267,7 @@ describe "Reports", type: :request do
     context "when the request is not valid" do
       let(:params) {  {"client-id" => "fake.fake", "target-id" => "BL" } }
 
-      before { post "/reports/transfer", params: params.to_json, headers: transfer_headers }
+      before { post "/reports/transfer", params: params.to_json, headers: headers }
 
       it "transfer all reports from a client" do
         expect(response).to have_http_status(404)
@@ -279,7 +277,7 @@ describe "Reports", type: :request do
     context "when the request is not valid" do
       let(:params) {  {"client-id" => reports_transfer.first.client_id } } 
 
-      before { post "/reports/transfer", params: params.to_json, headers: transfer_headers }
+      before { post "/reports/transfer", params: params.to_json, headers: headers }
 
       it "transfer all reports from a client" do
         expect(response).to have_http_status(422)
@@ -421,7 +419,7 @@ describe "Reports", type: :request do
       before { put "/reports/#{report.uid}", params: params.to_json, headers: headers }
 
       it "returns status code 400" do
-        expect(response).to have_http_status(400)
+        expect(response).to have_http_status(422)
         # expect(json["errors"].first).to eq("status"=>"422", "title"=>"You need to provide a payload following the SUSHI specification")
       end
     end

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -251,6 +251,42 @@ describe "Reports", type: :request do
     end
   end
 
+  describe "POST /reports/transfer" do
+    let!(:reports_transfer) { create_list(:report, 3, compressed: nil) }
+    let(:transfer_headers) { { "ACCEPT" => "json", "CONTENT_TYPE" => "json", "Authorization" => "Bearer " + bearer } }
+
+
+    context "when the request is valid" do
+      let(:params) {  { "client-id" => reports_transfer.first.client_id, "target-id" => "BL" } }
+
+      before { post "/reports/transfer", params: params.to_json, headers: transfer_headers }
+
+      it "transfer all reports from a client" do
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when the request is not valid" do
+      let(:params) {  {"client-id" => "fake.fake", "target-id" => "BL" } }
+
+      before { post "/reports/transfer", params: params.to_json, headers: transfer_headers }
+
+      it "transfer all reports from a client" do
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    context "when the request is not valid" do
+      let(:params) {  {"client-id" => reports_transfer.first.client_id } } 
+
+      before { post "/reports/transfer", params: params.to_json, headers: transfer_headers }
+
+      it "transfer all reports from a client" do
+        expect(response).to have_http_status(422)
+      end
+    end
+  end
+
   describe "PUT /reports/:id" do
     let!(:report) { create(:report) }
 


### PR DESCRIPTION
## Purpose

If a repository is transfered and this repository has usage reports, we need to update the report headers.

resolves: https://github.com/datacite/sashimi/issues/122

## Approach
<!--- _How does this change address the problem?_ -->

adds method to the reports endpoint to "transfer" reports from one provider to another


```json
POST /reports/transfer

{"client-id": "cdl.dryad", "target-id": "BL" } }

```

#### Open Questions and Pre-Merge TODOs
- none

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve  -->

## Status
- [x] Ready for Review

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
