### PR TITLE
Change the API to send different status codes depending of the status of the validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'iso_country_codes'
 gem 'sentry-raven', '~> 2.9'
 gem 'git', '~> 1.5'
 gem "sprockets", "~> 3.7", ">= 3.7.2"
+gem "aasm", "~> 5.0", ">= 5.0.1"
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (5.0.6)
+      concurrent-ruby (~> 1.0)
     actioncable (5.2.4.1)
       actionpack (= 5.2.4.1)
       nio4r (~> 2.0)
@@ -331,6 +333,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aasm (~> 5.0, >= 5.0.1)
   active_model_serializers (~> 0.10.10)
   api-pagination
   aws-sdk-s3
@@ -388,4 +391,4 @@ DEPENDENCIES
   webmock (~> 3.1)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ POST /reports
 | 201         | Report has been CREATED and validated correctly         |
 | 202         | Report has been ACCEPTED and its waiting for validation |
 | 404         | Report does not exists                                  |
-| 409         | Report or subreport has failed validation               |
+| 422         | Report or subreport has failed validation               |
 
 ### Metadata Validation
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,6 @@ POST /reports
 POST /reports
 ```
 
-
 ### HTTP Response Codes
 
 | Status Code | Message                                                 |
@@ -262,6 +261,8 @@ POST /reports
 | 202         | Report has been ACCEPTED and its waiting for validation |
 | 404         | Report does not exists                                  |
 | 422         | Report or subreport has failed validation               |
+
+One can use the filter paramaters `?incorrect=true` (422s) and `?queued=true` (202s) to list all the reports with validation errors or queued for validation, respectvely. 
 
 ### Metadata Validation
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,17 @@ POST /reports
 POST /reports
 ```
 
+
+### HTTP Response Codes
+
+| Status Code | Message                                                 |
+|-------------|---------------------------------------------------------|
+| 200         | Report has been updated                                 |
+| 201         | Report has been CREATED and validated correctly         |
+| 202         | Report has been ACCEPTED and its waiting for validation |
+| 404         | Report does not exists                                  |
+| 409         | Report or subreport has failed validation               |
+
 ### Metadata Validation
 
 The validation of the metadata in the reports its a two-step process. The controller takes care of checking presence of fields. Then the Schema validation is performed before saving the report. We use json-schema validation for this.

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -63,7 +63,17 @@ class ReportsController < ApplicationController
   end
 
   def show
-    render json: @report
+    case true
+    when @report.correct?
+      render json: @report, status: :ok
+    when @report.queued?
+      render json: @report, status: :accepted
+    when @report.incorrect?
+      render json: @report, status: :conflict
+    else
+      Rails.logger.warn @report.errors.inspect
+      render json: serialize(@report.errors), status: :unprocessable_entity
+    end
   end
 
   def update
@@ -82,7 +92,16 @@ class ReportsController < ApplicationController
     authorize! :update, @report
 
     if @report.update(safe_params.merge(@user_hash))
+      updated = true
+    end
+
+    case true 
+    when updated && @report.correct?
       render json: @report, status: exists ? :ok : :created
+    when updated && @report.queued?
+      render json: @report, status: :accepted
+    when updated && @report.incorrect?
+      render json: @report, status: :conflict
     else
       Rails.logger.warn @report.errors.inspect
       render json: serialize(@report.errors), status: :unprocessable_entity
@@ -104,7 +123,16 @@ class ReportsController < ApplicationController
     authorize! :create, @report
 
     if @report.save
+      saved = true
+    end
+
+    case true
+    when saved && @report.correct?
       render json: @report, status: :created
+    when saved && @report.queued?
+      render json: @report, status: :accepted
+    when saved && @report.incorrect?
+      render json: @report, status: :conflict
     else
       Rails.logger.error @report.errors.inspect
       render json: @report.errors, status: :unprocessable_entity

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -30,14 +30,16 @@ class ReportsController < ApplicationController
 
     collection = if params[:id].present?
                    Report.correct.where(uid: params[:id].split(","))
+                 elsif params[:incorrect].present?
+                   Report.incorrect.any? ? Report.incorrect.where(user_id: params[:client_id]) : []
+                 elsif params[:queued].present?
+                   Report.queued.any? ? Report.queued.where(user_id: params[:client_id] ) : []
                  elsif params[:created_by].present?
                    Report.correct.where(created_by: params[:created_by])
                  elsif params[:year].present?
                    Report.correct.where(year: params[:year])
                  elsif params[:client_id].present?
                    Report.correct.where(user_id: params[:client_id])
-                 elsif params[:incorrect].present?
-                   Report.incorrect.where(created_by: params[:created_by] || null, user_id: params[:client_id] || null)
                  else
                    Report.correct
                  end

--- a/app/jobs/update_validation_state_job.rb
+++ b/app/jobs/update_validation_state_job.rb
@@ -1,0 +1,10 @@
+require "benchmark"
+
+class UpdateValidationStateJob < ActiveJob::Base
+  queue_as :sashimi
+
+  def perform(id, _options = {})
+    report = Report.find(id: id)
+    report.update_state
+  end
+end

--- a/app/jobs/validation_job.rb
+++ b/app/jobs/validation_job.rb
@@ -1,50 +1,10 @@
-require 'benchmark'
+require "benchmark"
 
 class ValidationJob < ActiveJob::Base
   queue_as :sashimi
 
-  def perform(id, options={})
-    subset = nil
-    full_report = nil
-    subset = nil
-    header = nil
-    parsed = nil
-    is_valid = nil
-
-    bm = Benchmark.ms {
-      subset = ReportSubset.where(id: id).first
-      full_report = ActiveSupport::Gzip.decompress(subset.compressed)
-    }
-    Rails.logger.warn message: "[ValidationJob] Decompress", duration: bm
-
-    bm = Benchmark.ms {
-      parsed = JSON.parse(full_report)
-    }
-    Rails.logger.warn message: "[ValidationJob] Parse", duration: bm
-
-    header = parsed.dig("report-header")
-    header["report-datasets"] = parsed.dig("report-datasets")
-
-    bm = Benchmark.ms {
-      # validate subset of usage report, raise error with bug tracker otherwise
-      is_valid = subset.validate_this_sushi_with_error(header)
-    }
-    Rails.logger.warn message: "[ValidationJob] Validation", duration: bm
-
-    if is_valid
-      message = "[ValidationJob] Subset #{id} of Usage Report #{subset.report.uid} successfully validated."
-      subset.update_column(:aasm, "valid")
-      subset.push_report unless options[:validate_only]
-      Rails.logger.info message
-      true
-    else
-      # store error details in database
-      validation_errors =  subset.validate_this_sushi(header)
-
-      message = "[ValidationJobError] Subset #{id} of Usage Report #{subset.report.uid} failed validation. There are #{validation_errors.size} errors, starting with \"#{validation_errors.first[:message]}\"."
-      subset.update_columns(aasm: "not_valid", exceptions: validation_errors)
-      Rails.logger.error message
-      false
-    end
+  def perform(id, options = {})
+    subset = ReportSubset.find(id)
+    subset.validate_compressed(options)
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -58,9 +58,10 @@ class Report < ApplicationRecord
   # def validate_report_job
   #   ValidationJob.perform_later(self)
   # end
-
-  scope :correct, -> { where aasm_state: "correct" }
+  
+  scope :queued, -> { where aasm_state: "queued" }
   scope :incorrect, -> { where aasm_state: "incorrect" }
+  scope :correct, -> { where aasm_state: "correct" }
 
   def destroy_report_events
     DestroyEventsJob.perform_later(uid)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -15,6 +15,22 @@ class Report < ApplicationRecord
   # include validation methods for sushi
   include Queueable
 
+  include AASM
+
+  aasm do
+    state :queued, initial: true
+    state :valid, :invalid
+
+    event :accept do
+      transitions from: [:queued, :invalid], to: :valid
+    end
+
+    event :reject do
+      transitions from: [:queued, :valid], to: :invalid
+    end
+
+  end
+
   # attr_accessor :month, :year, :compressed
   validates_presence_of :report_id, :created_by, :user_id, :created, :reporting_period
   validates_presence_of :report_datasets, if: :normal_report?

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -98,11 +98,11 @@ class Report < ApplicationRecord
 
     case true
     when statuses.all? { |s| s == "valid" }
-      accept
+      accept!
     when statuses.any? { |s| s == "queued" }
-      validating
+      validating!
     else
-      reject
+      reject!
     end
   end
 

--- a/app/models/report_subset.rb
+++ b/app/models/report_subset.rb
@@ -8,7 +8,7 @@ class ReportSubset < ApplicationRecord
 
   # include validation methods for sushi
   include Metadatable
-
+  
   belongs_to :report, primary_key: "uid", foreign_key: "report_id"
 
   validates_presence_of :report_id
@@ -106,5 +106,6 @@ class ReportSubset < ApplicationRecord
 
   def set_id
     self.id = SecureRandom.random_number(9223372036854775807)
+    self.aasm = "queued"
   end
 end

--- a/app/models/report_subset.rb
+++ b/app/models/report_subset.rb
@@ -38,6 +38,50 @@ class ReportSubset < ApplicationRecord
     ::Base64.strict_encode64(compressed)
   end
 
+  def validate_compressed(options = {})
+    full_report = nil
+    header = nil
+    parsed = nil
+    is_valid = nil
+
+    bm = Benchmark.ms do
+      # subset = ReportSubset.where(id: id).first
+      full_report = ActiveSupport::Gzip.decompress(compressed)
+    end
+    Rails.logger.warn message: "[ValidationJob] Decompress", duration: bm
+
+    bm = Benchmark.ms do
+      parsed = JSON.parse(full_report)
+    end
+    Rails.logger.warn message: "[ValidationJob] Parse", duration: bm
+
+    header = parsed.dig("report-header")
+    header["report-datasets"] = parsed.dig("report-datasets")
+
+    bm = Benchmark.ms do
+      # validate subset of usage report, raise error with bug tracker otherwise
+      is_valid = validate_this_sushi_with_error(header)
+    end
+    Rails.logger.warn message: "[ValidationJob] Validation", duration: bm
+    if is_valid
+      message = "[ValidationJob] Subset #{id} of Usage Report #{report.uid} successfully validated."
+      update_column(:aasm, "valid")
+      report.update_state
+      push_report unless options[:validate_only]
+      Rails.logger.info message
+      true
+    else
+      # store error details in database
+      validation_errors = validate_this_sushi(header)
+
+      message = "[ValidationJobError] Subset #{id} of Usage Report #{report.uid} failed validation. There are #{validation_errors.size} errors, starting with \"#{validation_errors.first[:message]}\"."
+      update_columns(aasm: "not_valid", exceptions: validation_errors)
+      report.update_state
+      Rails.logger.error message
+      false
+    end
+  end
+
   def report_header
     report = Report.where(uid: report_id).first
 

--- a/app/validators/sushi_validator.rb
+++ b/app/validators/sushi_validator.rb
@@ -1,22 +1,24 @@
 class SushiValidator < ActiveModel::EachValidator
-
   def validate_each(record, _schema, _value)
-    # unless  record.is_valid_sushi? 
+    # unless  record.is_valid_sushi?
     valid = record.validate_sushi
+    record.accept if valid.empty?
+    return true if valid.empty?
+
     unless valid == true
 
       def dig_errors(errors)
         return [] if errors.nil?
-      
+
         if errors.is_a? Hash
-          [ errors.dig(:message) ]
+          [errors.dig(:message)]
         else
-          errors.map { |error| {error.dig(:fragment) => error.dig(:message)}  }
+          errors.map { |error| { error.dig(:fragment) => error.dig(:message) } }
         end
       end
       # nice_erros = dig_errors record.validate_sushi
       nice_erros = dig_errors valid
-
+      record.reject
       record.errors["errors"] << (nice_erros || "Your SUSHI is wrong mate!!")
     end
   end

--- a/app/validators/sushi_validator.rb
+++ b/app/validators/sushi_validator.rb
@@ -2,7 +2,7 @@ class SushiValidator < ActiveModel::EachValidator
   def validate_each(record, _schema, _value)
     # unless  record.is_valid_sushi?
     valid = record.validate_sushi
-    record.accept if valid.empty?
+    record.accept! if valid.empty?
     return true if valid.empty?
 
     unless valid == true
@@ -18,7 +18,7 @@ class SushiValidator < ActiveModel::EachValidator
       end
       # nice_erros = dig_errors record.validate_sushi
       nice_erros = dig_errors valid
-      record.reject
+      record.reject!
       record.errors["errors"] << (nice_erros || "Your SUSHI is wrong mate!!")
     end
   end

--- a/db/migrate/20200717141429_add_aasm_state_to_reports.rb
+++ b/db/migrate/20200717141429_add_aasm_state_to_reports.rb
@@ -1,0 +1,5 @@
+class AddAasmStateToReports < ActiveRecord::Migration[5.2]
+  def change
+    add_column :reports, :aasm_state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_13_101137) do
+ActiveRecord::Schema.define(version: 2020_07_17_141429) do
 
-  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
     t.bigint "record_id", null: false
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 2020_07_13_101137) do
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 2020_07_13_101137) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "error_models", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "error_models", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "code"
     t.string "severity"
     t.string "message"
@@ -43,7 +43,7 @@ ActiveRecord::Schema.define(version: 2020_07_13_101137) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "publishers", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "publishers", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "publisher_name"
     t.string "publisher_id"
     t.string "path"
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 2020_07_13_101137) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "report_subsets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "report_subsets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "report_id"
     t.binary "compressed", limit: 16777215
     t.string "checksum"
@@ -61,7 +61,7 @@ ActiveRecord::Schema.define(version: 2020_07_13_101137) do
     t.json "exceptions"
   end
 
-  create_table "report_types", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "report_types", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "report_id"
     t.string "release"
     t.string "report_description"
@@ -70,7 +70,7 @@ ActiveRecord::Schema.define(version: 2020_07_13_101137) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "reports", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "reports", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "report_name", default: "Dataset Report"
     t.string "report_id"
     t.string "user_id", null: false
@@ -88,17 +88,18 @@ ActiveRecord::Schema.define(version: 2020_07_13_101137) do
     t.string "uid"
     t.json "reporting_period"
     t.binary "compressed", limit: 16777215
+    t.string "aasm_state"
     t.index ["created_by", "month", "year"], name: "index_reports_on_multiple_columns", unique: true
   end
 
-  create_table "status_alerts", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "status_alerts", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "date_time"
     t.string "alert"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "statuses", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "statuses", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "description"
     t.boolean "service_active"
     t.string "registry_url"

--- a/spec/concerns/metadatable_spec.rb
+++ b/spec/concerns/metadatable_spec.rb
@@ -93,14 +93,14 @@ describe Report, type: :model do
       let(:xx)  {create(:report_subset, report_id: report_xx.uid)}
 
       it "should load drl" do
-        report = report_drl_hsh.attributes.except("compressed")
+        report = report_drl_hsh.attributes.except("compressed","aasm_state")
         report.transform_keys! { |key| key.tr('_', '-') }
         validation = drl.validate_this_sushi report
         expect(validation).to be_empty
       end
 
       it "should load rd1" do
-        report = report_rd1_hsh.attributes.except("compressed")
+        report = report_rd1_hsh.attributes.except("compressed","aasm_state")
         report.transform_keys! { |key| key.tr('_', '-') }
         validation = rd1.validate_this_sushi report
         expect(validation).to be_empty
@@ -112,7 +112,7 @@ describe Report, type: :model do
       # end
 
       it "should send error if mixed" do
-        report = report_rd1_hsh.attributes.except("compressed")
+        report = report_rd1_hsh.attributes.except("compressed","aasm_state")
         report.transform_keys! { |key| key.tr('_', '-') }
         validation = drl.validate_this_sushi(report)
         expect(validation).to be_a(Array)

--- a/spec/fixtures/files/report_error.json
+++ b/spec/fixtures/files/report_error.json
@@ -1,0 +1,75 @@
+{
+  "report-header": {
+    "report-name": "Dataset Master Report",
+    "report-id": "5cb09a1e-e204-48e7-b9b8-93327659ab43",
+    "release": "rd1",
+    "created-by": "urn:node:US-MPC",
+    "created": "2018-11-26",
+    "reporting-period": {
+      "end-date": "2015-06-30",
+      "begin-date": "2015-06-01"
+    },
+    "report-filters": [],
+    "report-attributes": [],
+    "exceptions": [{"code": 69,"severity": "warning","message": "report is compressed using gzip","help-url": "https://github.com/datacite/sashimi","data": "usage data needs to be uncompressed"}]
+  },
+  "report-datasets": [{
+    "uri": "https://cn.dataone.org/cn/v2/resolve/doi%3A10.5063%2FF16D5QX4",
+    "yop": "2014",
+    "dataset-id": [{
+      "type": "doi",
+      "value": "doi:10.5063/F16D5QX4"
+    }],
+    "performance": [{
+      "period": {
+        "end-date": "2015-06-30",
+        "begin-date": "2015-06-01"
+      },
+      "instance": [{
+        "count": 6,
+        "metric-type": "total-dataset-investigations",
+        "access-method": "regular",
+        "country-counts": {
+          "us": 6
+        }
+      }, {
+        "count": 3,
+        "metric-type": "unique-dataset-investigations",
+        "access-method": "regular",
+        "country-counts": {
+          "us": 3
+        }
+      }, {
+        "count": 1,
+        "metric-type": "total-dataset-requests",
+        "access-method": "regular",
+        "country-counts": {
+          "us": 1
+        }
+      }, {
+        "count": 1,
+        "metric-type": "unique-dataset-requests",
+        "access-method": "regular",
+        "country-counts": {
+          "us": 1
+        }
+      }]
+    }],
+    "publisher-id": [{
+      "type": "urn",
+      "value": "urn:node:KNB"
+    }],
+    "dataset-dates": [{
+      "type": "pub-date",
+      "value": "2014-07-18"
+    }],
+    "dataset-title": "Testing Amazon Transitional Forest Leaf Flammability: Leaf Traits (2013)",
+    "dataset-contributors": [{
+      "type": "name",
+      "value": "Amy Thissell"
+    }, {
+      "type": "name",
+      "value": "Jennifer Balch"
+    }]
+  }]
+}

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -18,7 +18,7 @@ describe Report, type: :model do
 
     it "it is valid" do
       subject.update_state
-      expect(subject.aasm_state).to eq("correct")
+      expect(subject.aasm_state).to eq("queued")
     end
 
     it "it is compressed" do

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -10,4 +10,27 @@ describe Report, type: :model do
     # it { should validate_presence_of(:report_datasets) }
     it { should validate_presence_of(:reporting_period) }
   end
+
+  describe "update_state" do
+    it "state is queued" do
+      expect(subject.aasm_state).to eq("correct")
+    end
+
+    it "it is valid" do
+      subject.update_state
+      expect(subject.aasm_state).to eq("correct")
+    end
+
+    it "it is compressed" do
+      expect(subject.compressed_report?).to eq(nil)
+    end
+
+    it "it is normal" do
+      expect(subject.normal_report?).to eq(true)
+    end
+
+    it "compressed" do
+      expect(subject.compress).to be_a(String)
+    end
+  end
 end


### PR DESCRIPTION
## Purpose

When sending compressed report is unclear when a report is validate correctly or not, because the validation happens in a background job.

closes: https://github.com/datacite/sashimi/issues/112

## Approach

Change the API to send different status codes depending of the status of the validation
details: https://github.com/datacite/sashimi/issues/112


### HTTP Response Codes

| Status Code | Message                                                 |
|-------------|---------------------------------------------------------|
| 200         | Report has been updated                                 |
| 201         | Report has been CREATED and validated correctly         |
| 202         | Report has been ACCEPTED and its waiting for validation |
| 404         | Report does not exists                                  |
| 422         | Report or subreport has failed validation               |


#### Open Questions and Pre-Merge TODOs
- [ ] Should Validate in stage that changes actually work.
- [ ] Need to communicate with implementations before pushing to production

## Status
- [x] Ready for Review

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
